### PR TITLE
Removed engine check function

### DIFF
--- a/qcsrc/client/Main.qc
+++ b/qcsrc/client/Main.qc
@@ -462,10 +462,6 @@ void SetMadokaFont(float v)
 	}
 }
 
-void Menu_ShowNagger(void) {
-    if(!DPRM_VersionIsRecommended())
-        localcmd("menu_cmd directmenu engineNagger\n");
-}
 
 void ReloadMenu_f()
 {


### PR DESCRIPTION
Because Xonotic clients support the DarkPlacesRM engine, but do not directly use it - the "engineNagger" function keeps triggering and giving a "false alert" about having an outdated engine.